### PR TITLE
Remove anonymous namespace giving compiler warnings.

### DIFF
--- a/include/threepp/Canvas.hpp
+++ b/include/threepp/Canvas.hpp
@@ -29,15 +29,11 @@ namespace threepp {
     };
 
 
-     namespace {
+    typedef std::pair<std::function<void()>, float> task;
 
-        typedef std::pair<std::function<void()>, float> task;
-
-        struct CustomComparator {
-            bool operator()(const task& l, const task& r) const { return l.second > r.second; }
-        };
-
-    }// namespace
+    struct CustomComparator {
+        bool operator()(const task& l, const task& r) const { return l.second > r.second; }
+    };
 
 
     class Canvas {
@@ -114,7 +110,7 @@ namespace threepp {
             friend struct Canvas::Impl;
         };
 
-        
+
         struct Impl {
 
             static const int KEY_ESCAPE = 1;


### PR DESCRIPTION
`Canvas.hpp:118:16: warning: ‘threepp::Canvas::Impl’ has a field ‘threepp::Canvas::Impl::tasks_’ whose type uses the anonymous namespace [-Wsubobject-linkage]`

This means that every cpp file which uses `task` and `CustomOperator` will have their own versions. This is apparently a violation of the One Definition Rule (despite the fact that the types are defined the same way) which is why the compiler warns about it.

AFAIK there's no reason to put these in an unnamed namespace, so I've removed it.
